### PR TITLE
Apply common subexpression elimination 

### DIFF
--- a/include/cg.hpp
+++ b/include/cg.hpp
@@ -16,7 +16,6 @@ struct Operation : std::enable_shared_from_this<Operation> {
   using Ptr = std::shared_ptr<Operation>;
   using WeakPtr = std::weak_ptr<Operation>;
   Operation();
-  Operation(const std::string& name);
   Operation(OpKind kind, std::vector<Operation::Ptr> args, int32_t hash_id);
   void to_cpp_expr(std::ostream& strm) const;
   static Operation::Ptr create(OpKind kind, std::vector<Operation::Ptr>&& args, int32_t hash_id);
@@ -35,7 +34,6 @@ struct Operation : std::enable_shared_from_this<Operation> {
   // member variables
   OpKind kind;
   std::vector<Operation::Ptr> args;
-  std::string name;
   int32_t hash_id;
   std::optional<std::string> ext_func_name;  // used only for EXTCALL kind
   std::optional<double> constant_value;      // used only for zero, one, constant

--- a/include/cg.hpp
+++ b/include/cg.hpp
@@ -17,9 +17,9 @@ struct Operation : std::enable_shared_from_this<Operation> {
   using WeakPtr = std::weak_ptr<Operation>;
   Operation();
   Operation(const std::string& name);
-  Operation(OpKind kind, std::vector<Operation::Ptr> args);
+  Operation(OpKind kind, std::vector<Operation::Ptr> args, int32_t hash_id);
   void to_cpp_expr(std::ostream& strm) const;
-  static Operation::Ptr create(OpKind kind, std::vector<Operation::Ptr>&& args);
+  static Operation::Ptr create(OpKind kind, std::vector<Operation::Ptr>&& args, int32_t hash_id);
   static Operation::Ptr make_var();
   static Operation::Ptr make_zero();
   static Operation::Ptr make_one();
@@ -36,6 +36,7 @@ struct Operation : std::enable_shared_from_this<Operation> {
   OpKind kind;
   std::vector<Operation::Ptr> args;
   std::string name;
+  int32_t hash_id;
   std::optional<std::string> ext_func_name;  // used only for EXTCALL kind
 };
 

--- a/include/cg.hpp
+++ b/include/cg.hpp
@@ -38,6 +38,7 @@ struct Operation : std::enable_shared_from_this<Operation> {
   std::string name;
   int32_t hash_id;
   std::optional<std::string> ext_func_name;  // used only for EXTCALL kind
+  std::optional<double> constant_value;      // used only for zero, one, constant
 };
 
 void flatten(const std::string& func_name,

--- a/src/cg.cpp
+++ b/src/cg.cpp
@@ -44,17 +44,10 @@ int32_t djb2_hash(const std::string& str) {
 
 Operation::Operation() : kind(OpKind::NIL) {
   hash_id = generate_random_int();
-  name = generate_random_string(8);
-}
-
-Operation::Operation(const std::string& name) : kind(OpKind::NIL), name(name) {
-  hash_id = generate_random_int();
 }
 
 Operation::Operation(OpKind kind, std::vector<Operation::Ptr> leafs, int32_t hash_id)
-    : kind(kind), args(leafs), hash_id(hash_id) {
-  name = generate_random_string(8);
-}
+    : kind(kind), args(leafs), hash_id(hash_id) {}
 
 Operation::Ptr Operation::create(OpKind kind,
                                  std::vector<Operation::Ptr>&& leafs,
@@ -69,21 +62,21 @@ Operation::Ptr Operation::make_var() {
 }
 
 Operation::Ptr Operation::make_zero() {
-  Operation::Ptr zero = std::make_shared<Operation>("0.0");
+  Operation::Ptr zero = std::make_shared<Operation>();
   zero->kind = OpKind::ZERO;
   zero->constant_value = 0.0;
   return zero;
 }
 
 Operation::Ptr Operation::make_one() {
-  Operation::Ptr one = std::make_shared<Operation>("1.0");
+  Operation::Ptr one = std::make_shared<Operation>();
   one->kind = OpKind::ONE;
   one->constant_value = 1.0;
   return one;
 }
 
 Operation::Ptr Operation::make_ext_func(std::string&& name, std::vector<Operation::Ptr>&& args) {
-  Operation::Ptr func = std::make_shared<Operation>(name);
+  Operation::Ptr func = std::make_shared<Operation>();
   func->kind = OpKind::EXTCALL;
   func->args = std::move(args);
   func->ext_func_name = std::move(name);
@@ -91,7 +84,7 @@ Operation::Ptr Operation::make_ext_func(std::string&& name, std::vector<Operatio
 }
 
 Operation::Ptr Operation::make_constant(double value) {
-  Operation::Ptr constant = std::make_shared<Operation>(std::to_string(value));
+  Operation::Ptr constant = std::make_shared<Operation>();
   constant->kind = OpKind::CONSTANT;
   constant->constant_value = value;
   return constant;

--- a/src/cg.cpp
+++ b/src/cg.cpp
@@ -71,12 +71,14 @@ Operation::Ptr Operation::make_var() {
 Operation::Ptr Operation::make_zero() {
   Operation::Ptr zero = std::make_shared<Operation>("0.0");
   zero->kind = OpKind::ZERO;
+  zero->constant_value = 0.0;
   return zero;
 }
 
 Operation::Ptr Operation::make_one() {
   Operation::Ptr one = std::make_shared<Operation>("1.0");
   one->kind = OpKind::ONE;
+  one->constant_value = 1.0;
   return one;
 }
 
@@ -91,6 +93,7 @@ Operation::Ptr Operation::make_ext_func(std::string&& name, std::vector<Operatio
 Operation::Ptr Operation::make_constant(double value) {
   Operation::Ptr constant = std::make_shared<Operation>(std::to_string(value));
   constant->kind = OpKind::CONSTANT;
+  constant->constant_value = value;
   return constant;
 }
 
@@ -125,7 +128,7 @@ Operation::Ptr operator+(Operation::Ptr lhs, Operation::Ptr rhs) {
     return lhs;
   }
   if (rhs->kind == OpKind::CONSTANT && lhs->kind == OpKind::CONSTANT) {
-    return Operation::make_constant(std::stod(lhs->name) + std::stod(rhs->name));
+    return Operation::make_constant(*lhs->constant_value + *rhs->constant_value);
   }
   auto this_hash_id = division_hash(lhs->hash_id + rhs->hash_id);
   return Operation::create(OpKind::ADD, {lhs, rhs}, this_hash_id);
@@ -138,7 +141,7 @@ Operation::Ptr operator-(Operation::Ptr lhs, Operation::Ptr rhs) {
     return lhs;
   }
   if (rhs->kind == OpKind::CONSTANT && lhs->kind == OpKind::CONSTANT) {
-    return Operation::make_constant(std::stod(lhs->name) - std::stod(rhs->name));
+    return Operation::make_constant(*lhs->constant_value - *rhs->constant_value);
   }
   auto this_hash_id = division_hash(lhs->hash_id - rhs->hash_id);
   return Operation::create(OpKind::SUB, {lhs, rhs}, this_hash_id);
@@ -154,7 +157,7 @@ Operation::Ptr operator*(Operation::Ptr lhs, Operation::Ptr rhs) {
     return lhs;
   }
   if (rhs->kind == OpKind::CONSTANT && lhs->kind == OpKind::CONSTANT) {
-    return Operation::make_constant(std::stod(lhs->name) * std::stod(rhs->name));
+    return Operation::make_constant(*lhs->constant_value * *rhs->constant_value);
   }
   auto this_hash_id = division_hash(lhs->hash_id * rhs->hash_id);
   return Operation::create(OpKind::MUL, {lhs, rhs}, this_hash_id);
@@ -163,7 +166,6 @@ Operation::Ptr cos(Operation::Ptr op) {
   if (op->kind == OpKind::ZERO) {
     return Operation::make_one();
   }
-  // int32_t to string
   auto tmp = "(cos)" + std::to_string(op->hash_id);
   auto this_hash_id = djb2_hash(tmp);
   return Operation::create(OpKind::COS, {op}, this_hash_id);

--- a/src/cg.cpp
+++ b/src/cg.cpp
@@ -4,6 +4,7 @@
 #include <random>
 #include <stack>
 #include <stdexcept>
+#include <string>
 
 namespace tenkai {
 
@@ -31,6 +32,14 @@ int32_t generate_random_int() {
 int32_t division_hash(int32_t x) {
   constexpr int32_t prime = 2147483647;
   return x % prime;
+}
+
+int32_t djb2_hash(const std::string& str) {
+  unsigned long hash = 5381;
+  for (char c : str) {
+    hash = ((hash << 5) + hash) + c;
+  }
+  return hash;
 }
 
 Operation::Operation() : kind(OpKind::NIL) {
@@ -154,13 +163,18 @@ Operation::Ptr cos(Operation::Ptr op) {
   if (op->kind == OpKind::ZERO) {
     return Operation::make_one();
   }
-  return Operation::create(OpKind::COS, {op}, 0);
+  // int32_t to string
+  auto tmp = "(cos)" + std::to_string(op->hash_id);
+  auto this_hash_id = djb2_hash(tmp);
+  return Operation::create(OpKind::COS, {op}, this_hash_id);
 }
 Operation::Ptr sin(Operation::Ptr op) {
   if (op->kind == OpKind::ZERO) {
     return Operation::make_zero();
   }
-  return Operation::create(OpKind::SIN, {op}, 0);
+  auto tmp = "(sin)" + std::to_string(op->hash_id);
+  auto this_hash_id = djb2_hash(tmp);
+  return Operation::create(OpKind::SIN, {op}, this_hash_id);
 }
 Operation::Ptr operator-(Operation::Ptr op) {
   if (op->kind == OpKind::ZERO) {

--- a/src/flatten.cpp
+++ b/src/flatten.cpp
@@ -1,8 +1,10 @@
 #include <dlfcn.h>
+#include <algorithm>
 #include <format>
 #include <fstream>
 #include <iostream>
 #include <stack>
+#include <string>
 #include <typeinfo>
 #include <unordered_map>
 #include "cg.hpp"
@@ -74,15 +76,30 @@ void flatten(const std::string& func_name,
   auto remapped_name = [&](const Operation::Ptr op) -> std::string {
     for (size_t i = 0; i < inputs.size(); ++i) {
       if (inputs[i] == op) {
+        if (op->kind != OpKind::VALIABLE) {
+          throw std::runtime_error("must not reach here");
+        }
         return std::format("input[{}]", i);
       }
     }
+
+    if (op->kind == OpKind::VALIABLE) {
+      throw std::runtime_error("must not reach here");
+    }
+
     for (size_t i = 0; i < outputs.size(); ++i) {
       if (outputs[i] == op) {
         return std::format("output[{}]", i);
       }
     }
-    return op->name;
+
+    // if zero/one/constant, return the value
+    if (op->kind == OpKind::ZERO || op->kind == OpKind::ONE || op->kind == OpKind::CONSTANT) {
+      return std::to_string(*op->constant_value);
+    }
+    auto var_name = std::to_string(op->hash_id);
+    std::replace(var_name.begin(), var_name.end(), '-', 'm');
+    return "var" + var_name;
   };
 
   // code generation

--- a/src/flatten.cpp
+++ b/src/flatten.cpp
@@ -99,7 +99,7 @@ void flatten(const std::string& func_name,
     }
     auto var_name = std::to_string(op->hash_id);
     std::replace(var_name.begin(), var_name.end(), '-', 'm');
-    return "var" + var_name;
+    return "var_" + var_name;
   };
 
   // code generation

--- a/test/test_basicmath.cpp
+++ b/test/test_basicmath.cpp
@@ -8,7 +8,7 @@ TEST(BasicMathTest, ConstantFolding) {
   auto d = a * b + c;
   EXPECT_EQ(d->is_nullaryop(), true);
   EXPECT_EQ(d->kind, tenkai::OpKind::CONSTANT);
-  EXPECT_EQ(std::stod(d->name), 6.0);
+  EXPECT_EQ(*d->constant_value, 6.0);
 }
 
 int main(int argc, char **argv) {

--- a/test/test_hash.cpp
+++ b/test/test_hash.cpp
@@ -26,6 +26,19 @@ TEST(HashTest, BasicMathTest) {
   }
 }
 
+TEST(HashTest, MathFuncTest) {
+  auto a = tenkai::Operation::make_var();
+  auto b = tenkai::Operation::make_var();
+  auto c = sin(a) + cos(a);
+  auto d = cos(a) + sin(a);
+  EXPECT_EQ(c->hash_id, d->hash_id);
+
+  // nested case
+  auto e = sin(sin((a + b) * c) + cos(a - b));
+  auto f = sin(cos(a - b) + sin(c * (a + b)));
+  EXPECT_EQ(e->hash_id, f->hash_id);
+}
+
 int main(int argc, char **argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();

--- a/test/test_hash.cpp
+++ b/test/test_hash.cpp
@@ -1,0 +1,32 @@
+#include "cg.hpp"
+#include <iostream>
+#include <gtest/gtest.h>
+
+TEST(HashTest, BasicMathTest) {
+  auto a = tenkai::Operation::make_var();
+  auto b = tenkai::Operation::make_var();
+  auto c = tenkai::Operation::make_var();
+  auto d = tenkai::Operation::make_var();
+  { // test commutative property
+    auto expr1 = a + b + c + d;
+    auto expr2 = d + c + b + a;
+    EXPECT_EQ(expr1->hash_id, expr2->hash_id);
+  }
+
+  { // test associative property
+    auto expr1 = (a + b) + (c + d);
+    auto expr2 = a + (b + c) + d;
+    EXPECT_EQ(expr1->hash_id, expr2->hash_id);
+  }
+
+  { // test distributive property
+    auto expr1 = (a + b) * c;
+    auto expr2 = a * c + b * c;
+    EXPECT_EQ(expr1->hash_id, expr2->hash_id);
+  }
+}
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
```cpp
void tmp(const double* input, double* output, void** extfns){
  auto var_2137921637 = cos(input[1]);
  auto var_m2516801 = cos(input[2]);
  auto var_m1170396325 = std::multiplies<double>()(var_2137921637, var_m2516801);
  auto var_m1658058798 = std::multiplies<double>()(var_m1170396325, input[0]);
  auto var_m488495388 = sin(input[2]);
  auto var_m1999194124 = std::multiplies<double>()(var_2137921637, var_m488495388);
  auto var_m697056840 = std::multiplies<double>()(var_m1999194124, input[1]);
  auto var_1939851658 = std::plus<double>()(var_m1658058798, var_m697056840);
  auto var_1514330442 = sin(input[1]);
  auto var_m1514330442 = std::negate<double>()(var_1514330442);
  auto var_m1044464086 = std::multiplies<double>()(var_m1514330442, input[2]);
  auto var_895387572 = std::plus<double>()(var_1939851658, var_m1044464086);
  output[0] = std::plus<double>()(var_895387572, var_895387572);
  auto var_m866582704 = sin(input[0]);
  auto var_1959042336 = std::multiplies<double>()(var_m866582704, var_1514330442);
  auto var_m333694240 = std::multiplies<double>()(var_1959042336, var_m2516801);
  auto var_m380604117 = cos(input[0]);
  auto var_488495388 = std::negate<double>()(var_m488495388);
  auto var_1704514484 = std::multiplies<double>()(var_m380604117, var_488495388);
  auto var_1370820244 = std::plus<double>()(var_m333694240, var_1704514484);
  auto var_238946488 = std::multiplies<double>()(var_1370820244, input[0]);
  auto var_615428224 = std::multiplies<double>()(var_1959042336, var_m488495388);
  auto var_m1733757163 = std::multiplies<double>()(var_m380604117, var_m2516801);
  auto var_m1118328939 = std::plus<double>()(var_615428224, var_m1733757163);
  auto var_1497867774 = std::multiplies<double>()(var_m1118328939, input[1]);
  auto var_1736814262 = std::plus<double>()(var_238946488, var_1497867774);
  auto var_1533819536 = std::multiplies<double>()(var_m866582704, var_2137921637);
  auto var_1105998448 = std::multiplies<double>()(var_1533819536, input[2]);
  auto var_m1452154586 = std::plus<double>()(var_1736814262, var_1105998448);
  output[1] = std::plus<double>()(var_m1452154586, var_m1452154586);
  auto var_m331077266 = std::multiplies<double>()(var_m380604117, var_1514330442);
  auto var_1873950994 = std::multiplies<double>()(var_m331077266, var_m2516801);
  auto var_866582704 = std::negate<double>()(var_m866582704);
  auto var_969491264 = std::multiplies<double>()(var_866582704, var_488495388);
  auto var_m1451525038 = std::plus<double>()(var_1873950994, var_969491264);
  auto var_m1745329396 = std::multiplies<double>()(var_m1451525038, input[0]);
  auto var_972503544 = std::multiplies<double>()(var_m331077266, var_m488495388);
  auto var_m1758330032 = std::multiplies<double>()(var_866582704, var_m2516801);
  auto var_m785826488 = std::plus<double>()(var_972503544, var_m1758330032);
  auto var_m478723152 = std::multiplies<double>()(var_m785826488, input[1]);
  auto var_2070914748 = std::plus<double>()(var_m1745329396, var_m478723152);
  auto var_m1932349961 = std::multiplies<double>()(var_m380604117, var_2137921637);
  auto var_1549307193 = std::multiplies<double>()(var_m1932349961, input[2]);
  auto var_m674745355 = std::plus<double>()(var_2070914748, var_1549307193);
  output[2] = std::plus<double>()(var_m674745355, var_m674745355);
}
```