### PR TITLE
refactor: use external register allocation algorithm

### DIFF
--- a/include/compile.hpp
+++ b/include/compile.hpp
@@ -4,48 +4,16 @@
 
 namespace tenkai {
 
-class Compiler {
- public:
-  struct Location {
-    size_t idx;
-    bool is_xmm;
-  };
+namespace compiler {
 
-  // used in constructor >>
-  Compiler(const std::vector<Operation::Ptr>& inputs,
-           const std::vector<Operation::Ptr>& outputs,
-           bool avx512);
-  static std::vector<Operation::Ptr> flatten(const std::vector<Operation::Ptr>& inputs,
-                                             const std::vector<Operation::Ptr>& outputs);
-  std::vector<std::vector<int32_t>> static compute_disappear_hashid_table(
-      const std::vector<Operation::Ptr>& operations);
-  // << used in constructor
+std::vector<Operation::Ptr> flatten(const std::vector<Operation::Ptr>& inputs,
+                                    const std::vector<Operation::Ptr>& outputs);
 
-  std::vector<uint8_t> generate_code();
-  JitFunc<double> compile();
+std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
+                                   const std::vector<Operation::Ptr>& outputs);
+JitFunc<double> compile(const std::vector<Operation::Ptr>& inputs,
+                        const std::vector<Operation::Ptr>& outputs);
 
- private:
-  void move_to_xmm0(int32_t hash_id, Xbyak::CodeGenerator& gen);
-  uint8_t get_xmm_register_idx(int32_t hash_id,
-                               std::vector<uint32_t>&& dont_spill_xmm,
-                               Xbyak::CodeGenerator& gen);
-  void untrack_disappear_hashid(size_t t);
-  void update_xmm_suvival_period();
-  size_t find_most_unused_xmm_idx(std::vector<uint32_t>&& exclude = {});
-  uint8_t get_avaialble_stack_index();
-  uint8_t get_available_xmm_index(Xbyak::CodeGenerator& gen);
-  void spill_register(uint8_t xmm_idx, Xbyak::CodeGenerator& gen);
-
-  std::vector<Operation::Ptr> inputs_;
-  std::vector<Operation::Ptr> outputs_;
-  std::vector<Operation::Ptr> operations_;
-  std::vector<std::vector<int32_t>> disappear_hashid_table_;
-
-  // internal state
-  std::vector<std::optional<int32_t>> xmm_usage_;
-  std::vector<std::optional<int32_t>> xmm_survival_period_;
-  std::vector<std::optional<int32_t>> stack_usage_;
-  std::unordered_map<int32_t, std::optional<Location>> ophash_to_location_;
-};
+}  // namespace compiler
 
 }  // namespace tenkai

--- a/include/register_alloc.hpp
+++ b/include/register_alloc.hpp
@@ -75,9 +75,10 @@ class RegisterAllocator {
         inputs_(inputs),
         outputs_(outputs),
         disappear_hashid_table_(compute_disappear_hashid_table(opseq)),
-        alloc_state_(inputs, opseq.size(), n_xmm),
+        alloc_state_(inputs, opseq.size(), n_xmm - 1),
         transition_sets_(opseq.size()),
-        t_(0) {}
+        t_(0),
+        temp_xmm_idx_(n_xmm - 1) {}
 
   std::vector<TransitionSet> allocate();
 
@@ -97,6 +98,7 @@ class RegisterAllocator {
   AllocState alloc_state_;
   std::vector<TransitionSet> transition_sets_;
   size_t t_;
+  size_t temp_xmm_idx_;  // used for temporary xmm e.g. bit mask in negation
 };
 
 }  // namespace register_alloc

--- a/include/register_alloc.hpp
+++ b/include/register_alloc.hpp
@@ -77,6 +77,7 @@ class RegisterAllocator {
 
  private:
   void spill_xmm(size_t idx);
+  void prepare_value_on_xmm(HashType hash_id, size_t dst_xmm_idx);
   size_t spill_and_prepare_xmm();
   void step() {
     ++t_;

--- a/include/register_alloc.hpp
+++ b/include/register_alloc.hpp
@@ -19,6 +19,12 @@ struct Location {
 
 std::ostream& operator<<(std::ostream& os, const Location& loc);
 
+struct ConstantSubstitution {
+  HashType hash_id;
+  double value;
+  Location dst;
+};
+
 struct RawTransition {
   HashType hash_id;
   Location src;
@@ -31,7 +37,7 @@ struct OpTransition {
   Location dst;
 };
 
-using Transition = std::variant<RawTransition, OpTransition>;
+using Transition = std::variant<RawTransition, OpTransition, ConstantSubstitution>;
 
 std::ostream& operator<<(std::ostream& os, const Transition& trans);
 

--- a/include/register_alloc.hpp
+++ b/include/register_alloc.hpp
@@ -76,6 +76,7 @@ class RegisterAllocator {
   std::vector<TransitionSet> allocate();
 
  private:
+  void spill_xmm(size_t idx);
   size_t spill_and_prepare_xmm();
   void step() {
     ++t_;

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -70,7 +70,7 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
 
   const auto& opseq_flatten = flatten(inputs, outputs);
   const auto& transset_seq =
-      register_alloc::RegisterAllocator(opseq_flatten, inputs, outputs).allocate();
+      register_alloc::RegisterAllocator(opseq_flatten, inputs, outputs, 3).allocate();
 
   auto gen = Xbyak::CodeGenerator(max_code_size);
   gen.endbr64();

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -70,7 +70,7 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
 
   const auto& opseq_flatten = flatten(inputs, outputs);
   const auto& transset_seq =
-      register_alloc::RegisterAllocator(opseq_flatten, inputs, outputs, 32).allocate();
+      register_alloc::RegisterAllocator(opseq_flatten, inputs, outputs, 16).allocate();
 
   auto gen = Xbyak::CodeGenerator(max_code_size);
   gen.endbr64();

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -78,8 +78,8 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
   gen.push(gen.r13);
   gen.push(gen.rbp);
   gen.mov(gen.rbp, gen.rsp);
-  // size_t sub_size = 8 * stack_usage_.size() + 8;  // +8 for x86_64 ABI (16 byte alignment)
-  // gen.sub(gen.rsp, sub_size);
+  size_t sub_size = 1024;  // temporary
+  gen.sub(gen.rsp, sub_size);
   gen.mov(gen.r12, gen.rdi);
   gen.mov(gen.r13, gen.rsi);
 
@@ -101,7 +101,7 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
             src = Xbyak::Xmm(raw_trans.src.idx);
             break;
           case register_alloc::LocationType::STACK:
-            src = gen.ptr[gen.rbp - raw_trans.src.idx * 8];
+            src = gen.ptr[gen.rbp - (raw_trans.src.idx + 1) * 8];
             break;
           default:
             throw std::runtime_error("not implemented");
@@ -111,7 +111,7 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
             dst = Xbyak::Xmm(raw_trans.dst.idx);
             break;
           case register_alloc::LocationType::STACK:
-            dst = gen.ptr[gen.rbp - raw_trans.dst.idx * 8];
+            dst = gen.ptr[gen.rbp - (raw_trans.dst.idx + 1) * 8];
             break;
           case register_alloc::LocationType::OUTPUT:
             dst = gen.ptr[gen.r13 + raw_trans.dst.idx * 8];

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -132,6 +132,13 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
         } else {
           throw std::runtime_error("not implemented");
         }
+      } else if (std::holds_alternative<register_alloc::ConstantSubstitution>(trans)) {
+        // TODO: shoule I prepare data section? but I guess just directly mov is
+        // faster becuase no need to load from memory
+        const auto& sub_trans = std::get<register_alloc::ConstantSubstitution>(trans);
+        uint64_t value_as_uint64 = std::bit_cast<uint64_t>(sub_trans.value);
+        gen.mov(gen.rax, value_as_uint64);
+        gen.movq(Xbyak::Xmm(sub_trans.dst.idx), gen.rax);
       } else if (std::holds_alternative<register_alloc::OpTransition>(trans)) {
         const auto& op_trans = std::get<register_alloc::OpTransition>(trans);
         auto dst = Xbyak::Xmm(op_trans.dst.idx);

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -11,9 +11,13 @@
 #include <stack>
 #include <stdexcept>
 #include <unordered_set>
+#include <variant>
 #include "cg.hpp"
+#include "register_alloc.hpp"
+#include "xbyak.h"
 
 namespace tenkai {
+namespace compiler {
 
 template <typename T>
 std::optional<size_t> find_index(T elem, const std::vector<T>& vec) {
@@ -28,20 +32,8 @@ std::optional<size_t> find_index(T elem, const std::vector<T>& vec) {
 // must be shared both xbyak constructor and mmap (why? really)
 constexpr size_t max_code_size = 4096 * 8;
 
-Compiler::Compiler(const std::vector<Operation::Ptr>& inputs,
-                   const std::vector<Operation::Ptr>& outputs,
-                   bool avx512)
-    : inputs_(inputs),
-      outputs_(outputs),
-      operations_(flatten(inputs, outputs)),
-      disappear_hashid_table_(compute_disappear_hashid_table(operations_)),
-      xmm_usage_((avx512) ? 31 : 15, std::nullopt),
-      xmm_survival_period_(xmm_usage_.size(), std::nullopt),
-      stack_usage_(1024, std::nullopt),
-      ophash_to_location_() {}
-
-std::vector<Operation::Ptr> Compiler::flatten(const std::vector<Operation::Ptr>& inputs,
-                                              const std::vector<Operation::Ptr>& outputs) {
+std::vector<Operation::Ptr> flatten(const std::vector<Operation::Ptr>& inputs,
+                                    const std::vector<Operation::Ptr>& outputs) {
   std::vector<Operation::Ptr> operations;
   std::stack<Operation::Ptr> opstack;
   for (auto& output : outputs) {
@@ -66,50 +58,19 @@ std::vector<Operation::Ptr> Compiler::flatten(const std::vector<Operation::Ptr>&
     visited.insert((*it)->hash_id);
     result.push_back(*it);
   }
-  // std::cout << "flatten operations:\n";
-  // for(size_t t = 0; t <result.size(); ++t){
-  //   auto op = result[t];
-  //   std::cout << std::format("  t: {}, hashid: {}, kind: {}", t, op->hash_id,
-  //   to_string(op->kind)); if (op->args.size() > 0) {
-  //     std::cout << ", args: ";
-  //     for(auto& arg : op->args) {
-  //       std::cout << std::format("{}, ", arg->hash_id);
-  //     }
-  //   }
-  //   std::cout << "\n";
-  // }
   return result;
 }
 
-std::vector<std::vector<int32_t>> Compiler::compute_disappear_hashid_table(
-    const std::vector<Operation::Ptr>& operations) {
-  std::vector<std::vector<int32_t>> table(operations.size());
-  std::unordered_set<int32_t> visited;
-  for (int i = operations.size() - 1; i >= 0; --i) {
-    for (auto& arg_op : operations[i]->args) {
-      bool unappended = visited.find(arg_op->hash_id) == visited.end();
-      if (unappended) {
-        table[i].push_back(arg_op->hash_id);
-        visited.insert(arg_op->hash_id);
-      }
-    }
-  }
-  // std::cout << "disappear hashid table:\n";
-  // for (size_t i = 0; i < table.size(); ++i) {
-  //   std::cout << std::format("  t={}: ", i);
-  //   for (auto hash_id : table[i]) {
-  //     std::cout << std::format("{}, ", hash_id);
-  //   }
-  //   std::cout << "\n";
-  // }
-  return table;
-}
-
-std::vector<uint8_t> Compiler::generate_code() {
+std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
+                                   const std::vector<Operation::Ptr>& outputs) {
   double (*sin_ptr)(double) = std::sin;
   void* sin_vptr = reinterpret_cast<void*>(sin_ptr);
   double (*cos_ptr)(double) = std::cos;
   void* cos_vptr = reinterpret_cast<void*>(cos_ptr);
+
+  const auto& opseq_flatten = flatten(inputs, outputs);
+  const auto& transset_seq =
+      register_alloc::RegisterAllocator(opseq_flatten, inputs, outputs).allocate();
 
   auto gen = Xbyak::CodeGenerator(max_code_size);
   gen.endbr64();
@@ -117,67 +78,85 @@ std::vector<uint8_t> Compiler::generate_code() {
   gen.push(gen.r13);
   gen.push(gen.rbp);
   gen.mov(gen.rbp, gen.rsp);
-  size_t sub_size = 8 * stack_usage_.size() + 8;  // +8 for x86_64 ABI (16 byte alignment)
-  gen.sub(gen.rsp, sub_size);
+  // size_t sub_size = 8 * stack_usage_.size() + 8;  // +8 for x86_64 ABI (16 byte alignment)
+  // gen.sub(gen.rsp, sub_size);
   gen.mov(gen.r12, gen.rdi);
   gen.mov(gen.r13, gen.rsi);
 
-  for (size_t t = 0; t < operations_.size(); ++t) {
-    const auto& op = operations_[t];
-    const auto& location = ophash_to_location_[op->hash_id];
-    auto available_xmm_idx = get_available_xmm_index(gen);
-    auto xmm_result = Xbyak::Xmm(available_xmm_idx);
-    xmm_survival_period_[available_xmm_idx] = 0;
+  for (size_t i = 0; i < opseq_flatten.size(); ++i) {
+    std::cout << "===============================" << std::endl;
+    const auto& op = opseq_flatten[i];
+    const register_alloc::TransitionSet& transset = transset_seq[i];
+    std::cout << std::format("operation name: {}", to_string(op->kind)) << std::endl;
+    for (const register_alloc::Transition& trans : transset) {
+      std::cout << trans;
+      if (std::holds_alternative<register_alloc::RawTransition>(trans)) {
+        std::variant<std::monostate, Xbyak::Address, Xbyak::Xmm> src, dst;
+        const auto& raw_trans = std::get<register_alloc::RawTransition>(trans);
+        switch (raw_trans.src.type) {
+          case register_alloc::LocationType::INPUT:
+            src = gen.ptr[gen.r12 + raw_trans.src.idx * 8];
+            break;
+          case register_alloc::LocationType::REGISTER:
+            src = Xbyak::Xmm(raw_trans.src.idx);
+            break;
+          case register_alloc::LocationType::STACK:
+            src = gen.ptr[gen.rbp - raw_trans.src.idx * 8];
+            break;
+          default:
+            throw std::runtime_error("not implemented");
+        }
+        switch (raw_trans.dst.type) {
+          case register_alloc::LocationType::REGISTER:
+            dst = Xbyak::Xmm(raw_trans.dst.idx);
+            break;
+          case register_alloc::LocationType::STACK:
+            dst = gen.ptr[gen.rbp - raw_trans.dst.idx * 8];
+            break;
+          case register_alloc::LocationType::OUTPUT:
+            dst = gen.ptr[gen.r13 + raw_trans.dst.idx * 8];
+            break;
+          default:
+            throw std::runtime_error("not implemented");
+        }
 
-    // update register/memory state
-    ophash_to_location_[op->hash_id] = Location{available_xmm_idx, true};
-    xmm_usage_[available_xmm_idx] = op->hash_id;
-
-    if (op->kind == OpKind::VALIABLE) {
-      auto input_idx = find_index(op, inputs_);
-      gen.vmovsd(xmm_result, gen.ptr[gen.r12 + input_idx.value() * 8]);
-    } else {
-      if (op->args.size() == 2) {
-        auto xmm_idx_left = get_xmm_register_idx(op->args[0]->hash_id, {available_xmm_idx}, gen);
-        auto xmm_idx_right =
-            get_xmm_register_idx(op->args[1]->hash_id, {available_xmm_idx, xmm_idx_left}, gen);
-        if (op->kind == OpKind::ADD) {
-          gen.vaddsd(xmm_result, Xbyak::Xmm(xmm_idx_left), Xbyak::Xmm(xmm_idx_right));
-        } else if (op->kind == OpKind::MUL) {
-          gen.vmulsd(xmm_result, Xbyak::Xmm(xmm_idx_left), Xbyak::Xmm(xmm_idx_right));
-        } else if (op->kind == OpKind::SUB) {
-          gen.vsubsd(xmm_result, Xbyak::Xmm(xmm_idx_left), Xbyak::Xmm(xmm_idx_right));
+        if (std::holds_alternative<Xbyak::Address>(src) &&
+            std::holds_alternative<Xbyak::Xmm>(dst)) {
+          gen.movsd(std::get<Xbyak::Xmm>(dst), std::get<Xbyak::Address>(src));
+        } else if (std::holds_alternative<Xbyak::Xmm>(src) &&
+                   std::holds_alternative<Xbyak::Address>(dst)) {
+          gen.movsd(std::get<Xbyak::Address>(dst), std::get<Xbyak::Xmm>(src));
         } else {
-          throw std::runtime_error("unsupported operation");
+          throw std::runtime_error("not implemented");
         }
-      } else if (op->args.size() == 1) {
-        // external call
-        // move all
-        move_to_xmm0(op->args[0]->hash_id, gen);
-        for (size_t i = 1; i < xmm_usage_.size(); ++i) {
-          if (xmm_usage_[i].has_value()) {
-            bool is_result_xmm = *xmm_usage_[i] == op->hash_id;
-            if (!is_result_xmm) {
-              spill_register(i, gen);
-            }
-          }
+      } else if (std::holds_alternative<register_alloc::OpTransition>(trans)) {
+        const auto& op_trans = std::get<register_alloc::OpTransition>(trans);
+        auto dst = Xbyak::Xmm(op_trans.dst.idx);
+        auto arg0 = Xbyak::Xmm(op_trans.xmms_src[0]);
+
+        if (op->kind == OpKind::NEGATE) {
+          throw std::runtime_error("not implemented");
         }
-        if (op->kind == OpKind::SIN) {
-          gen.call(sin_vptr);
-        } else if (op->kind == OpKind::COS) {
-          gen.call(cos_vptr);
+
+        Xbyak::Xmm arg1 = Xbyak::Xmm(op_trans.xmms_src[1]);
+        switch (op->kind) {
+          case OpKind::ADD:
+            gen.vaddsd(dst, arg0, arg1);
+            break;
+          case OpKind::SUB:
+            gen.vsubsd(dst, arg0, arg1);
+            break;
+          case OpKind::MUL:
+            gen.vmulsd(dst, arg0, arg1);
+            break;
+          default:
+            throw std::runtime_error(
+                std::format("not implemented operation name: {}", to_string(op->kind)));
         }
-        gen.vmovsd(xmm_result, Xbyak::Xmm(0));
+      } else {
+        throw std::runtime_error("not implemented");
       }
     }
-
-    // if op is output, store the result to memory
-    auto output_idx = find_index(op, outputs_);
-    if (output_idx.has_value()) {
-      gen.vmovsd(gen.ptr[gen.r13 + output_idx.value() * 8], xmm_result);
-    }
-    untrack_disappear_hashid(t);
-    update_xmm_suvival_period();
   }
 
   gen.mov(gen.rsp, gen.rbp);
@@ -191,8 +170,9 @@ std::vector<uint8_t> Compiler::generate_code() {
   return code;
 }
 
-JitFunc<double> Compiler::compile() {
-  auto code = generate_code();
+JitFunc<double> compile(const std::vector<Operation::Ptr>& inputs,
+                        const std::vector<Operation::Ptr>& outputs) {
+  auto code = generate_code(inputs, outputs);
   void* mem = mmap(NULL, max_code_size, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
   uint8_t* instruction = static_cast<uint8_t*>(mem);
   std::memcpy(instruction, code.data(), code.size());
@@ -201,113 +181,5 @@ JitFunc<double> Compiler::compile() {
   return add_func;
 }
 
-void Compiler::move_to_xmm0(int32_t hash_id, Xbyak::CodeGenerator& gen) {
-  auto location = ophash_to_location_[hash_id];
-  if (!location.has_value()) {
-    throw std::runtime_error("location not found. cannot move to xmm0");
-  }
-  if (location->is_xmm) {
-    if (location->idx == 0) {
-      return;  // already in xmm0
-    }
-    gen.vmovsd(Xbyak::Xmm(0), Xbyak::Xmm(location->idx));
-  } else {
-    gen.vmovsd(Xbyak::Xmm(0), gen.ptr[gen.rbp - (location->idx + 1) * 8]);
-  }
-}
-
-uint8_t Compiler::get_xmm_register_idx(int32_t hash_id,
-                                       std::vector<uint32_t>&& dont_spill_xmm,
-                                       Xbyak::CodeGenerator& gen) {
-  auto location = ophash_to_location_[hash_id];
-  if (!location.has_value()) {
-    throw std::runtime_error(
-        std::format("{} location not found. cannot get xmm register", hash_id));
-  }
-  if (location->is_xmm) {
-    return location->idx;
-  }
-  auto xmm_available_idx = get_available_xmm_index(gen);
-  gen.vmovsd(Xbyak::Xmm(xmm_available_idx), gen.ptr[gen.rbp - (location->idx + 1) * 8]);
-  std::cout << std::format("vmovsd xmm{}, [rbp - {} * 8]\n", xmm_available_idx, location->idx);
-  ophash_to_location_[hash_id] = Location{xmm_available_idx, true};
-  xmm_usage_[xmm_available_idx] = hash_id;
-  stack_usage_[location->idx] = std::nullopt;
-  return xmm_available_idx;
-}
-
-void Compiler::untrack_disappear_hashid(size_t t) {
-  for (int32_t hash_id : disappear_hashid_table_[t]) {
-    auto location = ophash_to_location_[hash_id];
-    if (!location.has_value()) {
-      throw std::runtime_error("location not found. cannot untrack disappear hashid");
-    }
-    if (location.has_value() && location->is_xmm) {
-      xmm_usage_[location->idx] = std::nullopt;
-      xmm_survival_period_[location->idx] = std::nullopt;
-    } else {
-      stack_usage_[location->idx] = std::nullopt;
-    }
-    ophash_to_location_[hash_id] = std::nullopt;
-  }
-}
-
-void Compiler::update_xmm_suvival_period() {
-  for (size_t i = 0; i < xmm_survival_period_.size(); ++i) {
-    if (xmm_survival_period_[i].has_value()) {
-      xmm_survival_period_[i] = *xmm_survival_period_[i] + 1;
-    }
-  }
-}
-
-size_t Compiler::find_most_unused_xmm_idx(std::vector<uint32_t>&& exclude) {
-  size_t most_unused_idx = 0;
-  size_t most_unused_period = 0;
-  for (size_t i = 0; i < xmm_survival_period_.size(); ++i) {
-    if (xmm_survival_period_[i].has_value() && *xmm_survival_period_[i] > most_unused_period) {
-      bool is_excluded = std::find(exclude.begin(), exclude.end(), i) != exclude.end();
-      if (is_excluded) {
-        continue;
-      }
-      most_unused_idx = i;
-      most_unused_period = *xmm_survival_period_[i];
-    }
-  }
-  return most_unused_idx;
-}
-
-uint8_t Compiler::get_avaialble_stack_index() {
-  for (size_t i = 0; i < stack_usage_.size(); ++i) {
-    if (stack_usage_[i] == std::nullopt) {
-      return i;
-    }
-  }
-  throw std::runtime_error("stack is full. this should not happen");
-}
-
-uint8_t Compiler::get_available_xmm_index(Xbyak::CodeGenerator& gen) {
-  for (size_t i = 1; i < xmm_usage_.size(); ++i) {
-    if (xmm_usage_[i] == std::nullopt) {
-      return i;
-    }
-  }
-  // spill register
-  auto xmm_idx = find_most_unused_xmm_idx();
-  spill_register(xmm_idx, gen);
-  return xmm_idx;
-}
-
-void Compiler::spill_register(uint8_t xmm_idx, Xbyak::CodeGenerator& gen) {
-  auto hash_id = *xmm_usage_[xmm_idx];
-  auto stack_idx = get_avaialble_stack_index();
-  gen.vmovsd(gen.ptr[gen.rbp - (stack_idx + 1) * 8], Xbyak::Xmm(xmm_idx));
-
-  // update internal state
-  xmm_usage_[xmm_idx] = std::nullopt;
-  xmm_survival_period_[xmm_idx] = std::nullopt;
-  stack_usage_[stack_idx] = hash_id;
-  auto new_loc = Location{stack_idx, false};
-  ophash_to_location_[hash_id] = new_loc;
-}
-
+}  // namespace compiler
 }  // namespace tenkai

--- a/src/register_alloc.cpp
+++ b/src/register_alloc.cpp
@@ -216,6 +216,10 @@ std::vector<TransitionSet> RegisterAllocator::allocate() {
         const auto& loc = alloc_state_.locations_[operand->hash_id];
         xmms_src.push_back(loc.idx);
       }
+      if (op->kind == OpKind::NEGATE) {
+        // use special xmm register to store bit mask for negation
+        xmms_src.push_back(temp_xmm_idx_);
+      }
 
       // untrack the hashids that will disappear
       // and free the registers and stack locations

--- a/test/test_compiler.cpp
+++ b/test/test_compiler.cpp
@@ -17,27 +17,32 @@ TEST(Compiler, Basic) {
   auto i1_sq = i1 * i1;
   auto i2_sq = i2 * i2;
   auto i3_sq = i3 * i3;
-  auto i4 = cos(i1_sq) + i2_sq + i3_sq;
+  // auto i4 = cos(i1_sq) + i2_sq + i3_sq;
+  auto i4 = i1_sq + i2_sq + i3_sq;
   auto i5 = i4 + i2;
   auto i6 = (i1_sq * i2_sq) + i3_sq;
-  auto i7 = i1 + sin(i2 * i3);
+  // auto i7 = i1 + sin(i2 * i3);
+  auto i7 = i1 + i2 * i3;
   auto ret = i5 + i3 + i6 + i7;
 
   // custom compiler
-  Compiler compiler({x, y, z, w}, {ret, i5, i3, i6, i7}, true);
-  tenkai::JitFunc<double> func = compiler.compile();
+  std::vector<Operation::Ptr> output = {i7, ret};
+  tenkai::JitFunc<double> func = compiler::compile({x, y, z, w}, output);
   double input[4] = {1.0, 2.0, 3.0, 4.0};
   double output_custom[5];
   func(input, output_custom, {});
 
   // gcc
   double output_gcc[5];
-  func = jit_compile<double>({x, y, z, w}, {ret, i5, i3, i6, i7});
+  func = jit_compile<double>({x, y, z, w}, output);
   func(input, output_gcc, {});
 
   // compare
-  for (int i = 0; i < 5; i++) {
-    ASSERT_NEAR(output_custom[i], output_gcc[i], 1e-6);
+  for (int i = 0; i < 2; i++) {
+    // print
+    std::cout << "output_custom[" << i << "] = " << output_custom[i] << std::endl;
+    std::cout << "output_gcc[" << i << "] = " << output_gcc[i] << std::endl;
+    // ASSERT_NEAR(output_custom[i], output_gcc[i], 1e-6);
   }
 }
 

--- a/test/test_compiler.cpp
+++ b/test/test_compiler.cpp
@@ -18,7 +18,7 @@ TEST(Compiler, Basic) {
   auto i2_sq = i2 * i2;
   auto i3_sq = i3 * i3;
   auto i4 = cos(i1_sq) + i2_sq + i3_sq;
-  auto i5 = i4 + i2;
+  auto i5 = i4 + i2 + Operation::make_constant(0.3);
   auto i6 = (i1_sq * i2_sq) + i3_sq;
   auto i7 = i1 + sin(i2 * i3);
   auto ret = i5 + i3 + i6 + i7;

--- a/test/test_compiler.cpp
+++ b/test/test_compiler.cpp
@@ -17,12 +17,10 @@ TEST(Compiler, Basic) {
   auto i1_sq = i1 * i1;
   auto i2_sq = i2 * i2;
   auto i3_sq = i3 * i3;
-  // auto i4 = cos(i1_sq) + i2_sq + i3_sq;
-  auto i4 = i1_sq + i2_sq + i3_sq;
+  auto i4 = cos(i1_sq) + i2_sq + i3_sq;
   auto i5 = i4 + i2;
   auto i6 = (i1_sq * i2_sq) + i3_sq;
-  // auto i7 = i1 + sin(i2 * i3);
-  auto i7 = i1 + i2 * i3;
+  auto i7 = i1 + sin(i2 * i3);
   auto ret = i5 + i3 + i6 + i7;
 
   // custom compiler
@@ -42,7 +40,7 @@ TEST(Compiler, Basic) {
     // print
     std::cout << "output_custom[" << i << "] = " << output_custom[i] << std::endl;
     std::cout << "output_gcc[" << i << "] = " << output_gcc[i] << std::endl;
-    // ASSERT_NEAR(output_custom[i], output_gcc[i], 1e-6);
+    ASSERT_NEAR(output_custom[i], output_gcc[i], 1e-6);
   }
 }
 

--- a/test/test_compiler.cpp
+++ b/test/test_compiler.cpp
@@ -22,9 +22,10 @@ TEST(Compiler, Basic) {
   auto i6 = (i1_sq * i2_sq) + i3_sq;
   auto i7 = i1 + sin(i2 * i3);
   auto ret = i5 + i3 + i6 + i7;
+  auto ret2 = -ret;
 
   // custom compiler
-  std::vector<Operation::Ptr> output = {i7, ret};
+  std::vector<Operation::Ptr> output = {i7, ret, ret2};
   tenkai::JitFunc<double> func = compiler::compile({x, y, z, w}, output);
   double input[4] = {1.0, 2.0, 3.0, 4.0};
   double output_custom[5];
@@ -36,7 +37,7 @@ TEST(Compiler, Basic) {
   func(input, output_gcc, {});
 
   // compare
-  for (int i = 0; i < 2; i++) {
+  for (int i = 0; i < 3; i++) {
     // print
     std::cout << "output_custom[" << i << "] = " << output_custom[i] << std::endl;
     std::cout << "output_gcc[" << i << "] = " << output_gcc[i] << std::endl;

--- a/test/test_register.cpp
+++ b/test/test_register.cpp
@@ -23,7 +23,7 @@ int main() {
   auto i7 = i1 + sin(i2 * i3);
   auto ret = i5 + i3 + i6 + i7;
 
-  auto opseq = Compiler::flatten({x, y, z, w}, {ret});
+  auto opseq = compiler::flatten({x, y, z, w}, {ret});
   register_alloc::RegisterAllocator regalloc(opseq, {x, y, z, w}, {ret}, 8);
   auto result = regalloc.allocate();
   for(auto& ss : result) {
@@ -39,7 +39,7 @@ int _main() {
   auto c = a + b; 
   auto d = a - b;
   std::vector<Operation::Ptr> inputs = {a, b};
-  auto opseq = Compiler::flatten(inputs, {c, d});
+  auto opseq = compiler::flatten(inputs, {c, d});
   register_alloc::RegisterAllocator regalloc(opseq, inputs, {c, d}, 2);
   auto result = regalloc.allocate();
 }


### PR DESCRIPTION
TODO (feature)
- [x] handle case when certain operation needs to overwrite the input register by the output register
- [x] handle case when the input registers must be ordered (xmm0, xmm1, ...) e.g. for sin/cos

TODO(perf):
- if register value is move to out, then stop tracking that value
- instead of using the age, rather use the interval between now to the time the register will be used next.
- movapd