### PR TITLE
[wip] feat: add packed spill

### DIFF
--- a/include/register_alloc.hpp
+++ b/include/register_alloc.hpp
@@ -31,13 +31,21 @@ struct RawTransition {
   Location dst;
 };
 
+struct RawPackedSpill {
+  HashType hash_id1;
+  HashType hash_id2;
+  size_t xmm_idx1;
+  size_t xmm_idx2;
+  size_t stack_head_idx;
+};
+
 struct OpTransition {
   HashType hash_id;
   std::vector<size_t> xmms_src;  // operands must be on xmm
   Location dst;
 };
 
-using Transition = std::variant<RawTransition, OpTransition, ConstantSubstitution>;
+using Transition = std::variant<RawTransition, OpTransition, ConstantSubstitution, RawPackedSpill>;
 
 std::ostream& operator<<(std::ostream& os, const Transition& trans);
 
@@ -50,6 +58,7 @@ struct AllocState {
   size_t most_unused_xmm() const;
   std::optional<size_t> get_available_xmm() const;
   size_t get_available_stack() const;
+  size_t get_available_stack_aligned_128bit() const;
 
   // udpate
   void update_xmm_ages();
@@ -84,6 +93,7 @@ class RegisterAllocator {
 
  private:
   void spill_xmm(size_t idx);
+  void spill_xmm_packed(size_t idx1, size_t idx2);
   void prepare_value_on_xmm(HashType hash_id, size_t dst_xmm_idx);
   size_t spill_and_prepare_xmm();
   void step() {

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -104,6 +104,21 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
         } else {
           throw std::runtime_error("not implemented");
         }
+      } else if (std::holds_alternative<register_alloc::RawPackedSpill>(trans)) {
+        const auto& packed_spill = std::get<register_alloc::RawPackedSpill>(trans);
+        auto xmm1 = Xbyak::Xmm(packed_spill.xmm_idx1);
+        auto xmm2 = Xbyak::Xmm(packed_spill.xmm_idx2);
+        // gen.vunpcklpd(xmm1, xmm1, xmm2);
+        gen.vunpcklpd(xmm1, xmm2, xmm1);
+        gen.vmovapd(gen.ptr[gen.rbp - (packed_spill.stack_head_idx + 1) * 8], xmm1);
+
+        // intentiallay cause segfault
+        // gen.mov(gen.rax, 0);
+        // gen.mov(gen.rcx, gen.ptr[gen.rax]);
+
+        // debug (use two vmovsd instead of vunpcklpd)
+        // gen.vmovsd(gen.ptr[gen.rbp - (packed_spill.stack_head_idx + 1) * 8], xmm1);
+        // gen.vmovsd(gen.ptr[gen.rbp - (packed_spill.stack_head_idx + 2) * 8], xmm2);
       } else if (std::holds_alternative<register_alloc::ConstantSubstitution>(trans)) {
         // TODO: shoule I prepare data section? but I guess just directly mov is
         // faster becuase no need to load from memory

--- a/src/compile.cpp
+++ b/src/compile.cpp
@@ -108,17 +108,16 @@ std::vector<uint8_t> generate_code(const std::vector<Operation::Ptr>& inputs,
         const auto& packed_spill = std::get<register_alloc::RawPackedSpill>(trans);
         auto xmm1 = Xbyak::Xmm(packed_spill.xmm_idx1);
         auto xmm2 = Xbyak::Xmm(packed_spill.xmm_idx2);
-        // gen.vunpcklpd(xmm1, xmm1, xmm2);
-        gen.vunpcklpd(xmm1, xmm2, xmm1);
-        gen.vmovapd(gen.ptr[gen.rbp - (packed_spill.stack_head_idx + 1) * 8], xmm1);
-
-        // intentiallay cause segfault
-        // gen.mov(gen.rax, 0);
-        // gen.mov(gen.rcx, gen.ptr[gen.rax]);
+        gen.vunpcklpd(Xbyak::Xmm(31), xmm2, xmm1);
+        gen.vmovapd(gen.ptr[gen.rbp - (packed_spill.stack_head_idx + 1 + 1) * 8], Xbyak::Xmm(31));
 
         // debug (use two vmovsd instead of vunpcklpd)
         // gen.vmovsd(gen.ptr[gen.rbp - (packed_spill.stack_head_idx + 1) * 8], xmm1);
         // gen.vmovsd(gen.ptr[gen.rbp - (packed_spill.stack_head_idx + 2) * 8], xmm2);
+
+        // intentiallay cause segfault
+        // gen.mov(gen.rax, 0);
+        // gen.mov(gen.rcx, gen.ptr[gen.rax]);
       } else if (std::holds_alternative<register_alloc::ConstantSubstitution>(trans)) {
         // TODO: shoule I prepare data section? but I guess just directly mov is
         // faster becuase no need to load from memory

--- a/src/register_alloc.cpp
+++ b/src/register_alloc.cpp
@@ -120,10 +120,7 @@ size_t AllocState::get_available_stack() const {
 }
 
 size_t AllocState::get_available_stack_aligned_128bit() const {
-  // NOTE: we search for stack idx head whic is odd number
-  // because stack actually is rbp and the first element is filled
-  // with rsp.
-  for (size_t i = 1; i < stack_usages_.size(); i += 2) {
+  for (size_t i = 0; i < stack_usages_.size(); i += 2) {
     if (stack_usages_[i] == std::nullopt && stack_usages_[i + 1] == std::nullopt) {
       return i;
     }


### PR DESCRIPTION
Currently, the code is buggy (compiled but results is not correct). 
Bug arises from the mismatch of memory grow direction in stack and register allocator. 
In the former, the direction is to lower, but the latter, to upper. 